### PR TITLE
Add password reset success flow

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
@@ -13,8 +13,8 @@ const ResetPasswordPage: React.FC = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
+  const [isSuccess, setIsSuccess] = useState(false)
   const [searchParams] = useSearchParams()
-  const navigate = useNavigate()
   
   const passwordStrength = validatePasswordStrength(password)
   const passwordsMatch = password === confirmPassword
@@ -56,13 +56,45 @@ const ResetPasswordPage: React.FC = () => {
         return
       }
 
-      // Success - redirect to dashboard
-      navigate('/dashboard')
+      await supabase.auth.signOut()
+      setIsSuccess(true)
     } catch (err) {
       setError('An unexpected error occurred. Please try again.')
     } finally {
       setIsLoading(false)
     }
+  }
+
+  if (isSuccess) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-brand-navy via-brand-navy/95 to-brand-purple/20 font-montserrat">
+        <Header />
+
+        <div className="flex items-center justify-center min-h-screen pt-20">
+          <div className="max-w-md w-full mx-4 py-8">
+            <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20 shadow-2xl">
+              <div className="text-center">
+                <div className="w-16 h-16 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-6">
+                  <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+                <h1 className="text-2xl font-bold text-white mb-4">Password Updated</h1>
+                <p className="text-white/80 mb-6">
+                  Your password has been reset. You can now sign in with your new password.
+                </p>
+                <Link
+                  to="/signin"
+                  className="block w-full bg-brand-teal hover:bg-brand-teal/90 text-white py-3 rounded-lg font-semibold transition-all"
+                >
+                  Go to Sign In
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- sign out users after password reset and show success screen
- link users to sign-in page after they reset their password

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5327161a8832a8acf59c456e3e949