### PR TITLE
Handle Stripe checkout race condition with success page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ResetPasswordPage from './pages/ResetPasswordPage'
 import GetStartedPage from './pages/GetStartedPage'
 import DashboardPage from './pages/DashboardPage'
 import DemoPage from './pages/DemoPage'
+import SuccessPage from './pages/SuccessPage'
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
           <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route path="/get-started" element={<GetStartedPage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/success" element={<SuccessPage />} />
           <Route path="/demo" element={<DemoPage />} />
         </Routes>
       </RouteGuard>

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -30,7 +30,7 @@ const RouteGuard: React.FC<RouteGuardProps> = ({ children }) => {
     }
 
     // Skip route guard for public pages
-    const publicPaths = ['/', '/pricing', '/signup', '/signin', '/forgot-password', '/reset-password', '/demo']
+    const publicPaths = ['/', '/pricing', '/signup', '/signin', '/forgot-password', '/reset-password', '/demo', '/success']
     if (publicPaths.includes(location.pathname)) {
       console.log('Public path, skipping guard')
       return

--- a/src/pages/SuccessPage.tsx
+++ b/src/pages/SuccessPage.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+const SuccessPage: React.FC = () => {
+  const { profile } = useAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (profile?.subscription_status === 'trialing' || profile?.subscription_status === 'active') {
+      navigate('/dashboard', { replace: true })
+    }
+  }, [profile, navigate])
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-teal mx-auto mb-4"></div>
+        <h1 className="text-xl font-semibold text-brand-navy mb-2">Setting up your subscription...</h1>
+        <p className="text-gray-600">Hang tight, you'll be redirected to your dashboard in a moment.</p>
+      </div>
+    </div>
+  )
+}
+
+export default SuccessPage

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -85,7 +85,7 @@ Deno.serve(async (req) => {
       mode: 'subscription',
       'line_items[0][price]': priceId,
       'line_items[0][quantity]': '1',
-      success_url: `${req.headers.get('origin')}/dashboard?session_id={CHECKOUT_SESSION_ID}`,
+      success_url: `${req.headers.get('origin')}/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${req.headers.get('origin')}/get-started`,
       customer_email: user.email,
       'metadata[user_id]': user.id,


### PR DESCRIPTION
## Summary
- Add intermediate Success page that waits for subscription status before redirecting
- Treat /success as public route and update checkout session success URL accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b633fe122c832a9246ac33f016fb83