### PR TITLE
Redirect signed-in users from signup

### DIFF
--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import Header from '../components/Header'
@@ -16,6 +16,13 @@ const SignupPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { isAuthenticated } = useAuth()
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/dashboard')
+    }
+  }, [isAuthenticated, navigate])
   
   const passwordStrength = validatePasswordStrength(password)
   const passwordsMatch = password === confirmPassword


### PR DESCRIPTION
## Summary
- redirect authenticated visitors away from signup page
- guard signup page via useAuth

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit --noUnusedLocals true --project tsconfig.json` *(fails: other unused declarations; none from SignupPage)*

------
https://chatgpt.com/codex/tasks/task_e_68b636196698832ab79fc3021697c4ed