### PR TITLE
Improve password reset flow with session validation and success messaging

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
@@ -14,21 +14,20 @@ const ResetPasswordPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [isSuccess, setIsSuccess] = useState(false)
-  const [searchParams] = useSearchParams()
   
   const passwordStrength = validatePasswordStrength(password)
   const passwordsMatch = password === confirmPassword
   const showPasswordMismatch = confirmPassword.length > 0 && !passwordsMatch
 
   useEffect(() => {
-    // Check if we have the required tokens
-    const accessToken = searchParams.get('access_token')
-    const refreshToken = searchParams.get('refresh_token')
-    
-    if (!accessToken || !refreshToken) {
-      setError('Invalid or expired reset link. Please request a new password reset.')
+    const verifySession = async () => {
+      const { data } = await supabase.auth.getSession()
+      if (!data.session?.user) {
+        setError('Invalid or expired reset link. Please request a new password reset.')
+      }
     }
-  }, [searchParams])
+    verifySession()
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -84,7 +83,7 @@ const ResetPasswordPage: React.FC = () => {
                   Your password has been reset. You can now sign in with your new password.
                 </p>
                 <Link
-                  to="/signin"
+                  to="/signin?message=password-reset-success"
                   className="block w-full bg-brand-teal hover:bg-brand-teal/90 text-white py-3 rounded-lg font-semibold transition-all"
                 >
                   Go to Sign In

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
@@ -11,14 +11,26 @@ const SigninPage: React.FC = () => {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
+  const [successMessage, setSuccessMessage] = useState('')
   const navigate = useNavigate()
   const { isAuthenticated } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   useEffect(() => {
     if (isAuthenticated) {
       navigate('/dashboard')
     }
   }, [isAuthenticated, navigate])
+
+  useEffect(() => {
+    const msg = searchParams.get('message')
+    if (msg === 'password-reset-success') {
+      setSuccessMessage('Your password has been reset. Please sign in with your new password.')
+      const params = new URLSearchParams(searchParams)
+      params.delete('message')
+      setSearchParams(params)
+    }
+  }, [searchParams, setSearchParams])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -59,6 +71,12 @@ const SigninPage: React.FC = () => {
               <h1 className="text-2xl font-bold text-white mb-2">Welcome Back</h1>
               <p className="text-white/80">Sign in to your CustomerPath account</p>
             </div>
+
+            {successMessage && (
+              <div className="mb-6 p-4 bg-green-500/20 border border-green-500/30 rounded-lg">
+                <p className="text-green-200 text-sm">{successMessage}</p>
+              </div>
+            )}
 
             {error && (
               <div className="mb-6 p-4 bg-red-500/20 border border-red-500/30 rounded-lg">


### PR DESCRIPTION
## Summary
- Verify Supabase recovery session before allowing password change
- Route password reset success back to login with a status message
- Display reset confirmation message on the sign-in page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6395bd0b0832a999bbd69f8ae960e