### PR TITLE
fix: validate password reset session

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -5,8 +5,6 @@ import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
 import { validatePasswordStrength } from '../utils/passwordValidation'
 import PasswordStrengthIndicator from '../components/PasswordStrengthIndicator'
-import { useAuth } from '../hooks/useAuth'
-
 const ResetPasswordPage: React.FC = () => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -16,7 +14,6 @@ const ResetPasswordPage: React.FC = () => {
   const [error, setError] = useState('')
   const [isSuccess, setIsSuccess] = useState(false)
   const [isValidSession, setIsValidSession] = useState(false)
-  const { user } = useAuth()
   
   const passwordStrength = validatePasswordStrength(password)
   const passwordsMatch = password === confirmPassword
@@ -25,22 +22,19 @@ const ResetPasswordPage: React.FC = () => {
   useEffect(() => {
     const checkSession = async () => {
       try {
-        const { data: { session }, error } = await supabase.auth.getSession()
-        
-        if (error) {
-          console.error('Session error:', error)
+        const {
+          data: { session },
+          error
+        } = await supabase.auth.getSession()
+
+        if (error || !session?.user) {
+          console.error('Session error or missing user:', error)
           setError('Invalid or expired reset link. Please request a new password reset.')
           return
         }
 
-        // Check if this is a password recovery session
-        if (session && user) {
-          console.log('Valid password recovery session found')
-          setIsValidSession(true)
-        } else {
-          console.log('No valid session for password reset')
-          setError('Invalid or expired reset link. Please request a new password reset.')
-        }
+        console.log('Valid password recovery session found')
+        setIsValidSession(true)
       } catch (err) {
         console.error('Error checking session:', err)
         setError('Invalid or expired reset link. Please request a new password reset.')
@@ -48,7 +42,7 @@ const ResetPasswordPage: React.FC = () => {
     }
 
     checkSession()
-  }, [user])
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -134,7 +128,7 @@ const ResetPasswordPage: React.FC = () => {
             <div className="text-center mb-8">
               <h1 className="text-2xl font-bold text-white mb-2">Set New Password</h1>
               <p className="text-white/80">Choose a strong password for your account</p>
-              {!isValidSession && (
+              {!isValidSession && !error && (
                 <div className="mt-4 p-3 bg-yellow-500/20 border border-yellow-500/30 rounded-lg">
                   <p className="text-yellow-200 text-sm">Validating reset link...</p>
                 </div>


### PR DESCRIPTION
## Summary
- handle Supabase password recovery by checking the session's user instead of relying on auth context
- only show the reset-link validation message when no error is present

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.js file)
- `npm run build` (fails: src/components/PaymentIssueBanner.tsx(21,43): Cannot find name 'supabase')

------
https://chatgpt.com/codex/tasks/task_e_68b6576a5830832aa25554faebe2eab1