### PR TITLE
Handle recovery token in reset password flow

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -22,6 +22,25 @@ const ResetPasswordPage: React.FC = () => {
   useEffect(() => {
     const checkSession = async () => {
       try {
+        const url = new URL(window.location.href)
+        // Supabase may send the recovery token as either a hash or search param
+        const hashParams = new URLSearchParams(url.hash.replace('#', ''))
+        const tokenHash =
+          hashParams.get('token_hash') || url.searchParams.get('token_hash')
+
+        if (tokenHash) {
+          const { error: verifyError } = await supabase.auth.verifyOtp({
+            token_hash: tokenHash,
+            type: 'recovery'
+          })
+
+          if (verifyError) {
+            console.error('Error verifying recovery token:', verifyError)
+            setError('Invalid or expired reset link. Please request a new password reset.')
+            return
+          }
+        }
+
         const {
           data: { session },
           error


### PR DESCRIPTION
## Summary
- handle Supabase recovery tokens on reset page to establish a valid session

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b88bec1a8c832a834ca54655c4d492